### PR TITLE
Remove toggle for light/dark mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,16 +23,16 @@ theme:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: vadc_platform
-      toggle:
-        icon: material/eye
-        name: Use a mouse-click or the up/down arrows to switch between light and dark mode. The site is currently in light mode.
+      #toggle:
+        #icon: material/eye
+        #name: Use a mouse-click or the up/down arrows to switch between light and dark mode. The site is currently in light mode.
 
     # Palette toggle for dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: vadc_platform_dark
-      toggle:
-        icon: material/eye-outline
-        name: Use a mouse-click or the up/down arrows to switch between light and dark mode. The site is currently in dark mode.
+    #- media: "(prefers-color-scheme: dark)"
+      #scheme: vadc_platform_dark
+      #toggle:
+        #icon: material/eye-outline
+        #name: Use a mouse-click or the up/down arrows to switch between light and dark mode. The site is currently in dark mode.
   features:
     - navigation.indexes
     - navigation.tracking


### PR DESCRIPTION
Because we could not make this toggle 508/accessibility compliant, we are resolving the 508 defect by removing the toggle entirely. 